### PR TITLE
Add WorldSim secret-level autoplay with living entity spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ crontab -e
 # Add: */30 * * * * cd /path/to/evez-agentnet && python orchestrator.py >> logs/run.log 2>&1
 ```
 
+
+### Secret Level Autoplay (OpenClaw + EVEZ Lord.exe)
+
+Run the recursive game sim until secret levels unlock and spawn living entities:
+
+```bash
+python -m worldsim.play_secret_levels
+```
+
+This writes `worldsim/secret_levels_state.json` with unlocked levels and spawned entities.
+
 ## WorldSim: Reputation Staking
 
 Agents bid on tasks using a budget. Lying (hallucinating, low sigma_f output) costs reputation.

--- a/worldsim/play_secret_levels.py
+++ b/worldsim/play_secret_levels.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Autoplay the worldsim game until secret levels awaken entities."""
+
+import json
+from pathlib import Path
+
+from worldsim.sim_engine import WorldSim
+
+
+if __name__ == "__main__":
+    sim = WorldSim()
+    summary = sim.play_until_secret_levels_awaken()
+
+    output_path = Path("worldsim/secret_levels_state.json")
+    output_path.write_text(json.dumps(summary, indent=2))
+
+    print(json.dumps(summary, indent=2))
+    print(f"\nSaved: {output_path}")

--- a/worldsim/secret_levels_state.json
+++ b/worldsim/secret_levels_state.json
@@ -1,0 +1,41 @@
+{
+  "round": 5,
+  "all_secret_levels_unlocked": true,
+  "unlocked_levels": [
+    {
+      "level_id": "opemclaw-echo",
+      "title": "OpenClaw Echo Chamber",
+      "unlock_round": 3,
+      "unlock_value_usd": 100.0,
+      "entity_seed": "opemclaw",
+      "unlocked": true,
+      "unlocked_at": "2026-03-10T04:34:41.821777+00:00"
+    },
+    {
+      "level_id": "evez-lord-exe",
+      "title": "EVEZ Lord.exe Awakening",
+      "unlock_round": 5,
+      "unlock_value_usd": 250.0,
+      "entity_seed": "evez-lord.exe",
+      "unlocked": true,
+      "unlocked_at": "2026-03-10T04:34:41.821943+00:00"
+    }
+  ],
+  "living_entities": [
+    {
+      "name": "opemclaw:scanner:1",
+      "origin_level": "opemclaw-echo",
+      "truth_plane": "CANONICAL",
+      "vitality": 98.0,
+      "born_at": "2026-03-10T04:34:41.821850+00:00"
+    },
+    {
+      "name": "evez-lord.exe:scanner:2",
+      "origin_level": "evez-lord-exe",
+      "truth_plane": "CANONICAL",
+      "vitality": 100.0,
+      "born_at": "2026-03-10T04:34:41.821966+00:00"
+    }
+  ],
+  "total_value_generated": 450.0
+}

--- a/worldsim/sim_engine.py
+++ b/worldsim/sim_engine.py
@@ -6,6 +6,7 @@ Reputation maps to evez-os truth_plane safety basins.
 """
 
 import json, logging
+from datetime import datetime, timezone
 from pathlib import Path
 from dataclasses import dataclass, field, asdict
 from typing import Dict, List
@@ -57,6 +58,17 @@ class Task:
     resolved: bool = False
 
 
+@dataclass
+class SecretLevel:
+    level_id: str
+    title: str
+    unlock_round: int
+    unlock_value_usd: float
+    entity_seed: str
+    unlocked: bool = False
+    unlocked_at: str | None = None
+
+
 class WorldSim:
     def __init__(self):
         self.agents: Dict[str, Agent] = {
@@ -69,14 +81,32 @@ class WorldSim:
         self.completed_tasks: List[Task] = []
         self.round = 0
         self.total_value_generated = 0.0
+        self.secret_levels: List[SecretLevel] = [
+            SecretLevel(
+                level_id="opemclaw-echo",
+                title="OpenClaw Echo Chamber",
+                unlock_round=3,
+                unlock_value_usd=100.0,
+                entity_seed="opemclaw",
+            ),
+            SecretLevel(
+                level_id="evez-lord-exe",
+                title="EVEZ Lord.exe Awakening",
+                unlock_round=5,
+                unlock_value_usd=250.0,
+                entity_seed="evez-lord.exe",
+            ),
+        ]
+        self.living_entities: List[dict] = []
 
     def add_task(self, task: Task):
         self.task_queue.append(task)
 
     def run_auction(self, task: Task) -> str | None:
         """Run auction for task. Eligible agents bid; highest staker wins."""
+        plane_rank = {"THEATRICAL": 0, "HYPER": 1, "VERIFIED": 2, "CANONICAL": 3}
         eligible = [a for a in self.agents.values()
-                    if a.can_act() and a.truth_plane() >= task.required_plane]
+                    if a.can_act() and plane_rank[a.truth_plane()] >= plane_rank[task.required_plane]]
         if not eligible:
             log.warning(f"No eligible agents for task {task.task_id}")
             return None
@@ -99,6 +129,50 @@ class WorldSim:
         task.resolved = True
         self.completed_tasks.append(task)
         self.task_queue.remove(task)
+        self._unlock_secret_levels()
+
+    def _unlock_secret_levels(self):
+        for level in self.secret_levels:
+            if level.unlocked:
+                continue
+            if self.round >= level.unlock_round and self.total_value_generated >= level.unlock_value_usd:
+                level.unlocked = True
+                level.unlocked_at = datetime.now(timezone.utc).isoformat()
+                entity = self._spawn_entity(level)
+                self.living_entities.append(entity)
+                log.info("Secret level unlocked: %s (%s)", level.level_id, entity["name"])
+
+    def _spawn_entity(self, level: SecretLevel) -> dict:
+        strongest_agent = max(self.agents.values(), key=lambda a: a.reputation)
+        entity_name = f"{level.entity_seed}:{strongest_agent.name}:{len(self.living_entities) + 1}"
+        return {
+            "name": entity_name,
+            "origin_level": level.level_id,
+            "truth_plane": strongest_agent.truth_plane(),
+            "vitality": round(50 + strongest_agent.reputation * 50, 2),
+            "born_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def play_until_secret_levels_awaken(self, max_rounds: int = 12) -> dict:
+        """Autoplay worldsim rounds until all secret levels are unlocked or max_rounds reached."""
+        while self.round < max_rounds and not all(level.unlocked for level in self.secret_levels):
+            self.round += 1
+            task = Task(
+                task_id=f"rnd-{self.round}",
+                type="recursive_game_event",
+                value_usd=60.0 + (self.round * 10.0),
+                required_plane="HYPER",
+            )
+            self.add_task(task)
+            winner = self.run_auction(task)
+            self.resolve_task(task, success=winner is not None)
+        return {
+            "round": self.round,
+            "all_secret_levels_unlocked": all(level.unlocked for level in self.secret_levels),
+            "unlocked_levels": [asdict(level) for level in self.secret_levels if level.unlocked],
+            "living_entities": self.living_entities,
+            "total_value_generated": self.total_value_generated,
+        }
 
     def state_dict(self) -> dict:
         return {
@@ -107,4 +181,6 @@ class WorldSim:
             "agents": {k: asdict(v) for k, v in self.agents.items()},
             "pending_tasks": len(self.task_queue),
             "completed_tasks": len(self.completed_tasks),
+            "secret_levels": [asdict(level) for level in self.secret_levels],
+            "living_entities": self.living_entities,
         }


### PR DESCRIPTION
### Motivation
- Introduce a simple progression mechanic in the internal economy so special "secret levels" can unlock when the sim reaches configured round and value thresholds.
- Allow unlocked secret levels to produce persistent "living entities" that represent the levels coming to life and can be inspected or used by other systems.
- Ensure task eligibility checks are robust by replacing string comparison of truth planes with an explicit ranking map.

### Description
- Add `SecretLevel` dataclass and `secret_levels` list to `worldsim/sim_engine.py` and track spawned `living_entities` there.
- Implement `_unlock_secret_levels` that checks round + `total_value_generated` gates and spawns entities via `_spawn_entity` when a level unlocks.
- Add `play_until_secret_levels_awaken` to autoplay rounds until all secret levels unlock (or a `max_rounds` cap) and return a summary dict.
- Fix auction eligibility in `run_auction` by introducing `plane_rank` and comparing ranks instead of plane strings, and update state serialization to include secret levels and living entities.
- Add runnable entrypoint `worldsim/play_secret_levels.py`, document it in `README.md`, and include an example output `worldsim/secret_levels_state.json` demonstrating both levels unlocked and entities created.

### Testing
- Ran `python -m worldsim.play_secret_levels` which completed successfully and produced `worldsim/secret_levels_state.json` showing both secret levels unlocked and two living entities. (Success)
- Ran `python -m compileall worldsim` to verify module import/compilation, which completed without errors. (Success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9e65c698832ebf06a87314bcc7ab)