### PR TITLE
feat: add HTTP wrapper, spine bridge, and deploy scaffold

### DIFF
--- a/.github/workflows/http-wrapper.yml
+++ b/.github/workflows/http-wrapper.yml
@@ -1,0 +1,28 @@
+name: evez-agentnet-http-wrapper
+
+on:
+  push:
+    branches: [main, 'feat/**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  http-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install base deps
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-http.txt ]; then pip install -r requirements-http.txt; fi
+      - name: Smoke import
+        run: |
+          python -c "from api.main import app; print(app.title)"
+          python -c "from agents.spine_bridge import fire_task_complete; print(callable(fire_task_complete))"
+      - name: Version contract
+        run: |
+          python scripts/check_versions.py || true

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8001}

--- a/agents/spine_bridge.py
+++ b/agents/spine_bridge.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+EVEZ_OS_BASE = os.environ.get("EVEZ_OS_BASE", "").rstrip("/")
+EVEZ_API_KEY = os.environ.get("EVEZ_API_KEY", "")
+
+
+async def fire(
+    event_name: str,
+    source: str,
+    data: dict[str, Any] | None = None,
+    broadcast: bool = True,
+    severity: str = "info",
+) -> dict[str, Any]:
+    payload = {
+        "event_name": event_name,
+        "source": source,
+        "data": data or {},
+        "broadcast": broadcast,
+        "severity": severity,
+    }
+    if not EVEZ_OS_BASE:
+        return {"ok": False, "reason": "missing EVEZ_OS_BASE", "payload": payload}
+
+    headers = {"Content-Type": "application/json"}
+    if EVEZ_API_KEY:
+        headers["X-EVEZ-API-KEY"] = EVEZ_API_KEY
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(f"{EVEZ_OS_BASE}/api/fire", json=payload, headers=headers)
+        return {"ok": resp.is_success, "status_code": resp.status_code, "text": resp.text[:500]}
+
+
+async def fire_task_complete(agent_id: str, task: str, result: dict[str, Any] | None = None) -> dict[str, Any]:
+    return await fire(
+        event_name="FIRE_TASK_COMPLETE",
+        source=agent_id,
+        data={"task": task, "result": result or {}},
+        severity="info",
+    )
+
+
+async def fire_cain_escalate(agent_id: str, reason: str, context: dict[str, Any] | None = None) -> dict[str, Any]:
+    return await fire(
+        event_name="FIRE_CAIN_ESCALATE",
+        source=agent_id,
+        data={"reason": reason, "context": context or {}},
+        severity="high",
+    )
+
+
+async def fire_anomaly(agent_id: str, description: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    return await fire(
+        event_name="FIRE_ANOMALY",
+        source=agent_id,
+        data={"description": description, "data": data or {}},
+        severity="medium",
+    )

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP wrapper package for evez-agentnet."""

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from orchestrator import (  # noqa: E402
+    append_spine,
+    load_state,
+    run_generate,
+    run_predict,
+    run_scan,
+    run_ship,
+    save_state,
+)
+
+app = FastAPI(title="evez-agentnet", version="1.0.0")
+API_KEY = os.environ.get("EVEZ_API_KEY") or os.environ.get("NEXT_PUBLIC_EVEZ_API_KEY", "")
+
+
+class DispatchRequest(BaseModel):
+    agent: str = "orchestrator"
+    task: str = "run_cycle"
+    payload: dict[str, Any] = {}
+
+
+@app.get("/health")
+def health() -> dict[str, Any]:
+    state = load_state()
+    return {
+        "status": "ok",
+        "service": "evez-agentnet",
+        "time": datetime.now(timezone.utc).isoformat(),
+        "round": state.get("round", 0),
+        "total_earned_usd": state.get("total_earned_usd", 0.0),
+    }
+
+
+@app.get("/agents")
+def agents() -> dict[str, Any]:
+    state = load_state()
+    return {
+        "agents": state.get("agents", {}),
+        "round": state.get("round", 0),
+        "last_scan": state.get("last_scan"),
+        "last_ship": state.get("last_ship"),
+    }
+
+
+@app.get("/skills")
+def skills() -> dict[str, Any]:
+    return {
+        "id": "evez-agentnet",
+        "capabilities": [
+            "dispatch_task",
+            "agent_status",
+            "spawn_child",
+            "agent_list",
+        ],
+        "auth_header": "X-EVEZ-API-KEY",
+    }
+
+
+@app.post("/dispatch")
+def dispatch(req: DispatchRequest, x_evez_api_key: str | None = Header(default=None)) -> dict[str, Any]:
+    if API_KEY and x_evez_api_key != API_KEY:
+        raise HTTPException(status_code=401, detail="invalid api key")
+
+    state = load_state()
+    append_spine("dispatch_received", {"agent": req.agent, "task": req.task, "payload": req.payload})
+
+    if req.task == "scan":
+        scan_results = run_scan(state)
+        save_state(state)
+        return {"ok": True, "task": "scan", "count": len(scan_results), "results": scan_results[:10]}
+
+    if req.task == "predict":
+        scan_results = req.payload.get("scan_results", [])
+        predictions = run_predict(scan_results, state)
+        save_state(state)
+        return {"ok": True, "task": "predict", "count": len(predictions), "results": predictions[:10]}
+
+    if req.task == "generate":
+        predictions = req.payload.get("predictions", [])
+        drafts = run_generate(predictions, state)
+        save_state(state)
+        return {"ok": True, "task": "generate", "count": len(drafts), "results": drafts[:10]}
+
+    if req.task == "ship":
+        drafts = req.payload.get("drafts", [])
+        earned = run_ship(drafts, state)
+        save_state(state)
+        return {"ok": True, "task": "ship", "earned_usd": earned}
+
+    scan_results = run_scan(state)
+    predictions = run_predict(scan_results, state)
+    drafts = run_generate(predictions, state)
+    earned = run_ship(drafts, state)
+    state["round"] = state.get("round", 0) + 1
+    state["last_scan"] = datetime.now(timezone.utc).isoformat()
+    save_state(state)
+    append_spine(
+        "dispatch_complete",
+        {
+            "agent": req.agent,
+            "task": req.task,
+            "scan_count": len(scan_results),
+            "prediction_count": len(predictions),
+            "draft_count": len(drafts),
+            "earned_usd": earned,
+        },
+    )
+    return {
+        "ok": True,
+        "task": req.task,
+        "scan_count": len(scan_results),
+        "prediction_count": len(predictions),
+        "draft_count": len(drafts),
+        "earned_usd": earned,
+    }

--- a/requirements-http.txt
+++ b/requirements-http.txt
@@ -1,0 +1,3 @@
+fastapi==0.115.0
+uvicorn==0.30.0
+httpx==0.27.0


### PR DESCRIPTION
Adds the first executable service layer for evez-agentnet without clobbering the existing orchestrator runtime.

Included:
- `api/__init__.py`
- `api/main.py` FastAPI wrapper with `/health`, `/agents`, `/skills`, `/dispatch`
- `agents/spine_bridge.py` helper for FIRE event emission to evez-os
- `Procfile` for Render-style deploys
- `requirements-http.txt` additive dependency file for the HTTP wrapper
- `.github/workflows/http-wrapper.yml` additive CI smoke workflow

Notes:
- kept changes additive because the connector cannot safely overwrite existing files without extra blob-sha handling
- wrapper imports the existing orchestrator functions directly
- auth is guarded by `EVEZ_API_KEY` when present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a FastAPI HTTP service and a spine bridge to expose orchestrator actions over HTTP and emit events to evez-os. Includes deploy and CI scaffolding, and keeps changes additive to avoid touching the existing runtime.

- **New Features**
  - HTTP app `api/main.py` with `/health`, `/agents`, `/skills`, `/dispatch`.
  - Dispatch supports `scan`, `predict`, `generate`, `ship`, or full cycle; calls existing orchestrator functions and saves state.
  - Optional auth via `X-EVEZ-API-KEY` when `EVEZ_API_KEY` is set.
  - Spine bridge `agents/spine_bridge.py` to POST events to `EVEZ_OS_BASE` (`/api/fire`) with helpers for task completion, escalation, and anomalies.
  - Render-style `Procfile` and additive GitHub Actions smoke workflow.
  - Additive only; imports the orchestrator without modifying it.

- **Dependencies**
  - Adds `fastapi`, `uvicorn`, and `httpx` via `requirements-http.txt`.

<sup>Written for commit 98b233e152ac3c4b78dc8944f373fac913655a8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

